### PR TITLE
enable badger truncate to fix db corruptions

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -31,6 +31,7 @@ func defaultBadgerOptions(
 	// By default, we do not compress the table at all. Doing so can
 	// significantly increase memory usage.
 	opts.Compression = options.None
+	opts.Truncate = true
 
 	return opts
 }


### PR DESCRIPTION
Fixes #16 

- Fixes corruption when process is abruptly shutdown (power outage etc)
- Also fixes the issue in the linked issue where db is corrupted after nil pointer error

Resources:
- https://github.com/dgraph-io/badger/issues/434
- https://github.com/dgraph-io/badger/issues/744
- https://github.com/dgraph-io/badger/issues/476